### PR TITLE
Fix version of gh-pages deployment action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Deploy
         # https://github.com/JamesIves/github-pages-deploy-action
-        uses: JamesIves/github-pages-deploy-action@4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: editor-app/out


### PR DESCRIPTION
The action is failing to run, unable to find the version of the action. I must have followed an outdated guide, the official repo shows @v4 as the recommended way to target it.