### PR TITLE
Removed forward slashes to allow the pages to load in a subdirectory

### DIFF
--- a/editor-app/components/DiagramPersistence.tsx
+++ b/editor-app/components/DiagramPersistence.tsx
@@ -26,7 +26,7 @@ const DiagramPersistence = (props: any) => {
   const [examples, setExamples] = useState<Example[]>([]);
 
   useEffect(() => {
-    fetch("/examples/index.json")
+    fetch("examples/index.json")
       .then(res => {
         if (!res.ok) {
           console.log(`Fetching examples index failed: ${res.status}`);

--- a/editor-app/components/NavBar.tsx
+++ b/editor-app/components/NavBar.tsx
@@ -49,17 +49,17 @@ function CollapsibleExample() {
       <Container className="border-bottom pb-3 mb-3">
       
       <Link className="navbar-brand" href="/">
-      <picture><img src="/Logo_Apollo.png" height="56" alt=""></img></picture>
+      <picture><img src="Logo_Apollo.png" height="56" alt=""></img></picture>
   </Link>
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
         <Navbar.Collapse id="responsive-navbar-nav">
           <Nav className="me-auto">
-            <NavItem href="/editor">Editor</NavItem>
-            <NavItem href="/manual">Guide</NavItem>
+            <NavItem href="editor">Editor</NavItem>
+            <NavItem href="manual">Guide</NavItem>
             <NavDropdown title="Activity Modelling">
-              <NavDropdown.Item href="/intro">Introduction</NavDropdown.Item>
-              <NavDropdown.Item href="/crane">Example Analysis</NavDropdown.Item>
-              <NavDropdown.Item href="/management">Integrated Information Management</NavDropdown.Item>
+              <NavDropdown.Item href="intro">Introduction</NavDropdown.Item>
+              <NavDropdown.Item href="crane">Example Analysis</NavDropdown.Item>
+              <NavDropdown.Item href="management">Integrated Information Management</NavDropdown.Item>
             </NavDropdown>
           </Nav>
         </Navbar.Collapse>

--- a/editor-app/pages/crane.tsx
+++ b/editor-app/pages/crane.tsx
@@ -22,7 +22,7 @@ export default function Page() {
   </div>
         <Row className="justify-content-center row-cols-1 row-cols-lg-2">
           <Col>
-            <p><picture><img className="w-100" src="crane/crane-lift.jpeg" alt=""/></picture></p>
+            <p><picture><img className="w-100" src="crane/crane-lift.jpeg" alt="" /></picture></p>
 
             <p>This document walks through the process of analysing the
             data required to perform an industrial activity, in this
@@ -168,7 +168,7 @@ export default function Page() {
             diagram view showing sub-tasks of the chosen task. Now start
             creating activities as before.</p>
 
-            <picture><ModalImage small="crane/sub-inspect-first.svg" large="/crane/sub-inspect-first.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/sub-inspect-first.svg" large="crane/sub-inspect-first.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <p>Create new individuals as needed; these will also show

--- a/editor-app/pages/crane.tsx
+++ b/editor-app/pages/crane.tsx
@@ -12,7 +12,7 @@ export default function Page() {
       <Head>
         <title>Analysing a crane lift</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
       <div className="row">
@@ -22,7 +22,7 @@ export default function Page() {
   </div>
         <Row className="justify-content-center row-cols-1 row-cols-lg-2">
           <Col>
-            <p><picture><img className="w-100" src="/crane/crane-lift.jpeg" alt=""/></picture></p>
+            <p><picture><img className="w-100" src="crane/crane-lift.jpeg" alt=""/></picture></p>
 
             <p>This document walks through the process of analysing the
             data required to perform an industrial activity, in this
@@ -31,7 +31,7 @@ export default function Page() {
             activity analysis method.</p>
 
             <p>This analysis performs Step 2 of the {}<Link
-            href="/intro">information requirements methodology</Link>,
+            href="intro">information requirements methodology</Link>,
             that of identifying all participants involved in the
             activity in question and breaking down the steps in the
             activity until decision points can be identified.</p>
@@ -90,7 +90,7 @@ export default function Page() {
             <h3>Representing a step on the diagram</h3>
 
             <p>Take the first step in the process as documented, and {}
-            <Link href="/manual#creating-a-diagram">represent it on the
+            <Link href="manual#creating-a-diagram">represent it on the
             diagram</Link>. Horizontal boxes represent physical objects
             involved in the process: people, machines, documents,
             anything at all in the real world that might affect the
@@ -101,7 +101,7 @@ export default function Page() {
             involved in this step of the activity.
             </p>
 
-            <picture><ModalImage small="/crane/rams-briefing.svg" large="/crane/rams-briefing.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/rams-briefing.svg" large="crane/rams-briefing.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <p>There are two people involved in this activity; they have
@@ -120,9 +120,9 @@ export default function Page() {
             them to the activity steps they are involved in.
             </p>
 
-            <picture><ModalImage small="/crane/rams-review.svg" large="/crane/rams-review.svg" imageBackgroundColor="#fff" alt="" /></picture>
-            <br/><picture><ModalImage small="/crane/rams-walk-route.svg" large="/crane/rams-walk-route.svg" imageBackgroundColor="#fff" alt="" /></picture>
-            <br/><picture><ModalImage small="/crane/rams-complete.svg" large="/crane/rams-complete.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/rams-review.svg" large="crane/rams-review.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <br/><picture><ModalImage small="crane/rams-walk-route.svg" large="crane/rams-walk-route.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <br/><picture><ModalImage small="crane/rams-complete.svg" large="crane/rams-complete.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <p>The analysis at this point is very much following the
@@ -145,7 +145,7 @@ export default function Page() {
             <p>Here is one of the steps from the lift above, represented
             on a separate diagram.</p>
 
-            <picture><ModalImage small="/crane/sub-inspect-inspect.svg" large="/crane/sub-inspect-inspect.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/sub-inspect-inspect.svg" large="crane/sub-inspect-inspect.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <p>Looking into the activity at this level of detail has
@@ -163,26 +163,26 @@ export default function Page() {
             model these situations; work is ongoing.</p>
 
             <p>To create a sub-task breakdown like this, <Link
-            href="/manual#breaking-down-activities">open the sub-tasks
+            href="manual#breaking-down-activities">open the sub-tasks
             of one of the existing steps</Link>. This will open a new
             diagram view showing sub-tasks of the chosen task. Now start
             creating activities as before.</p>
 
-            <picture><ModalImage small="/crane/sub-inspect-first.svg" large="/crane/sub-inspect-first.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/sub-inspect-first.svg" large="/crane/sub-inspect-first.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <p>Create new individuals as needed; these will also show
             up on the top-level view.</p>
 
-            <picture><ModalImage small="/crane/sub-inspect-quarantine.svg" large="/crane/sub-inspect-quarantine.svg" imageBackgroundColor="#fff" alt="" /></picture>
-            <br/><picture><ModalImage small="/crane/sub-inspect-inspect.svg" large="/crane/sub-inspect-inspect.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/sub-inspect-quarantine.svg" large="crane/sub-inspect-quarantine.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <br/><picture><ModalImage small="crane/sub-inspect-inspect.svg" large="crane/sub-inspect-inspect.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <p>Once the sub-task has been analysed, it is helpful to go
             back to the top-level view and add the new individuals
             identified as participants in the top-level activity.</p>
 
-            <picture><ModalImage small="/crane/sub-inspect-top.svg" large="/crane/sub-inspect-top.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/sub-inspect-top.svg" large="crane/sub-inspect-top.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <p>This can be loaded as an example in the Editor.</p>
@@ -235,7 +235,7 @@ export default function Page() {
             requires the crane&apos;s working limits, which were
             supplied to us at the time the crane was bought.</p>
 
-            <picture><ModalImage small="/crane/life-crane.svg" large="/crane/life-crane.svg" imageBackgroundColor="#fff" alt="" /></picture>
+            <picture><ModalImage small="crane/life-crane.svg" large="crane/life-crane.svg" imageBackgroundColor="#fff" alt="" /></picture>
             <br/>
 
             <h3>Deciding where to stop</h3>

--- a/editor-app/pages/editor.tsx
+++ b/editor-app/pages/editor.tsx
@@ -8,7 +8,7 @@ export default function Editor() {
         <title>Activity Diagram Editor | Editor</title>
         <meta name="description" content="HDQM activity diagram editor" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="favicon.ico" />
       </Head>
 
       <ActivityDiagramWrap />

--- a/editor-app/pages/index.tsx
+++ b/editor-app/pages/index.tsx
@@ -32,7 +32,7 @@ export default function Home() {
           <p className="lead">Knowing what information is needed to support any
             business activity is not easy. Especially engineering activities such as product assembly and life cycle mangement.
             It is crucial that relevant information requirements can be discovered by following a standardised and thorough approach.</p>
-            <Link className="btn btn-outline-secondary" href="/intro">Learn more</Link>
+            <Link className="btn btn-outline-secondary" href="intro">Learn more</Link>
         </div>
         <div className="bg-white box-shadow mx-auto"></div>
       </div>
@@ -45,7 +45,7 @@ export default function Home() {
           required consistently. The information output of which can be analysed as logical diagrams or machine-readable data for
           expanded data integration. <br></br>Well constructed activity models can aid business process improvement, 
           information quality managemement, performance measurement and planning.  </p>
-          <Link className="btn btn-outline-secondary" href="/crane">See an example</Link>
+          <Link className="btn btn-outline-secondary" href="crane">See an example</Link>
         </div>
         <div className="bg-white box-shadow mx-auto"></div>
       </div>
@@ -70,7 +70,7 @@ export default function Home() {
           the user interface hides the theory and complexity, whilst providing you the benefits of such a 
           comprehensive approach.   </p>
           <p>Methodologies such as these will prove essential for the adoption and use of integrated information management.</p>
-          <Link className="btn btn-outline-secondary" href="/management">Find out more</Link>
+          <Link className="btn btn-outline-secondary" href="management">Find out more</Link>
         </div>
     </div>
     <div className="col text-center align-self-center"><Image src={example} alt="

--- a/editor-app/pages/index.tsx
+++ b/editor-app/pages/index.tsx
@@ -16,7 +16,7 @@ export default function Home() {
       <div className="col-md-5 p-lg-5 mx-auto my-5">
         <h1 className="display-4 font-weight-normal">Activity Model Development Tool</h1>
         <p className="lead font-weight-normal">Learn and practice planning in a new way. Helping you discover all the information you need for complete decision making and resource planning.</p>
-        <Link className="btn btn-outline-secondary" href="/editor">Go To Editor</Link>
+        <Link className="btn btn-outline-secondary" href="editor">Go To Editor</Link>
       </div>
       <div className="product-device box-shadow d-none d-md-block"></div>
       <div className="product-device product-device-2 box-shadow d-none d-md-block"></div>
@@ -81,7 +81,7 @@ export default function Home() {
               temporal extent on the Time axis. Where a resource
               participates in an activity the overlapping area is
               shaded.
-            " className="img-fluid"/></div>
+            " className="img-fluid" /></div>
   </div>
 </div>
 

--- a/editor-app/pages/intro.tsx
+++ b/editor-app/pages/intro.tsx
@@ -15,7 +15,7 @@ export default function Page() {
       <Head>
         <title>Activity Modelling Introduction</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
       <div className="row">

--- a/editor-app/pages/intro.tsx
+++ b/editor-app/pages/intro.tsx
@@ -50,7 +50,7 @@ export default function Page() {
           </Col>
           <Col className="col-md text-center align-self-center">
             <Image src={flowchart} alt="The four-step activity modelling 
-            method as a flowchart." className="img-fluid mb-5 mt-3"/>
+            method as a flowchart." className="img-fluid mb-5 mt-3" />
           </Col>
         </Row>
         <Row className="justify-content-center row-cols-1 row-cols-lg-2 mt-5">
@@ -113,13 +113,13 @@ export default function Page() {
               temporal extent on the Time axis. Where a resource
               participates in an activity the overlapping area is
               shaded.
-            " className="img-fluid mb-5"/>
+            " className="img-fluid mb-5" />
           </Col>
         </Row>
 
-        <Link className="btn btn-outline-secondary mr-1" href="/crane">See an example</Link>
+        <Link className="btn btn-outline-secondary mr-1" href="crane">See an example</Link>
         <p></p>
-        <Link className="btn btn-outline-secondary" href="/editor">Try the editor</Link>
+        <Link className="btn btn-outline-secondary" href="editor">Try the editor</Link>
 
       </Container>
     </>

--- a/editor-app/pages/management.tsx
+++ b/editor-app/pages/management.tsx
@@ -4,15 +4,13 @@ import Link from "next/link";
 import { Col, Container, Row } from "react-bootstrap";
 import styles from "@/styles/Home.module.css";
 
-import sevenCircles from "@/public/7CirclesMedium2.png";
-
 export default function Page() {
   return (
     <>
       <Head>
         <title>Integrated information management</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
       <div className="row">
@@ -38,8 +36,8 @@ export default function Page() {
             <p><Link href="https://www.theiet.org/impact-society/factfiles/built-environment-factfiles/the-apollo-protocol-unifying-digital-twins-across-sectors/">Apollo Protocol</Link></p>
           </Col>
           <Col className="col-md text-center">
-            <Image src={sevenCircles} className="w-100 mt-3" alt="A layered view of what's needed
-            for integrated information management."/>
+            <picture><img src="7CirclesMedium2.png" className="w-100 mt-3" alt="A layered view of what's needed
+            for integrated information management"></img></picture>
             <p className="amrc-fixme">Elements of integrated information 
             management</p>
           </Col>

--- a/editor-app/pages/manual.tsx
+++ b/editor-app/pages/manual.tsx
@@ -54,7 +54,7 @@ export default function Page() {
             individual participates in a particular task.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage small="/manual/boil-egg-basic.svg" large="/manual/boil-egg-basic.svg" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage small="manual/boil-egg-basic.svg" large="/manual/boil-egg-basic.svg" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100 mt-5"></div>
     <div className="col-md"><h2 className="text-primary">Creating A Diagram</h2></div>
@@ -74,7 +74,7 @@ export default function Page() {
             Individual&rsquo; button.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="/manual/add-individual.png" large="/manual/add-individual.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/add-individual.png" large="/manual/add-individual.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
     
@@ -93,7 +93,7 @@ export default function Page() {
             that are created or destroyed as part of the activity.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="mw-100 mb-5" small="/manual/created-individuals.png" large="/manual/created-individuals.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="mw-100 mb-5" small="manual/created-individuals.png" large="/manual/created-individuals.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
     
@@ -110,7 +110,7 @@ export default function Page() {
 
             
     </div>
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="/manual/add-activity.png" large="/manual/add-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/add-activity.png" large="/manual/add-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 
@@ -126,7 +126,7 @@ export default function Page() {
             a new individual, save the activity and come back in to it
             when you&apos;ve created the individual.</p>
     </div>
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="/manual/created-activity.png" large="/manual/created-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="manual/created-activity.png" large="/manual/created-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100 mt-5"></div>
     <div className="col-md"><h2 className="text-primary">Changing A Diagram</h2></div>
@@ -156,7 +156,7 @@ export default function Page() {
             to model this level of detail becomes more important.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="/manual/edit-participant.png" large="/manual/edit-participant.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/edit-participant.png" large="/manual/edit-participant.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
 
     <div className="w-100"></div>
@@ -208,7 +208,7 @@ export default function Page() {
             and then click the &lsquo;Sub-tasks&rsquo; button.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="/manual/sub-tasks.png" large="/manual/sub-tasks.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/sub-tasks.png" large="/manual/sub-tasks.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 
@@ -226,7 +226,7 @@ export default function Page() {
             project is to promote discussion of these questions.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="/manual/sub-activities.png" large="/manual/sub-activities.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="manual/sub-activities.png" large="/manual/sub-activities.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100 mt-5"></div>
     <div className="col-md"><h2 className="text-primary">Saving and Loading Diagrams</h2></div>
@@ -249,7 +249,7 @@ export default function Page() {
             can be reused across diagrams.</p>
     </div>
 
-    <div className="col text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="/manual/save-load-ttl.png" large="/manual/save-load-ttl.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/save-load-ttl.png" large="/manual/save-load-ttl.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 
@@ -264,7 +264,7 @@ export default function Page() {
             href="/crane">the example analysis</Link>.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-25 mb-5" small="/manual/load-example.png" large="/manual/load-example.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-25 mb-5" small="manual/load-example.png" large="/manual/load-example.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 

--- a/editor-app/pages/manual.tsx
+++ b/editor-app/pages/manual.tsx
@@ -54,7 +54,7 @@ export default function Page() {
             individual participates in a particular task.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage small="manual/boil-egg-basic.svg" large="/manual/boil-egg-basic.svg" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage small="manual/boil-egg-basic.svg" large="manual/boil-egg-basic.svg" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100 mt-5"></div>
     <div className="col-md"><h2 className="text-primary">Creating A Diagram</h2></div>
@@ -74,7 +74,7 @@ export default function Page() {
             Individual&rsquo; button.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/add-individual.png" large="/manual/add-individual.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/add-individual.png" large="manual/add-individual.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
     
@@ -93,7 +93,7 @@ export default function Page() {
             that are created or destroyed as part of the activity.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="mw-100 mb-5" small="manual/created-individuals.png" large="/manual/created-individuals.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="mw-100 mb-5" small="manual/created-individuals.png" large="manual/created-individuals.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
     
@@ -110,7 +110,7 @@ export default function Page() {
 
             
     </div>
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/add-activity.png" large="/manual/add-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/add-activity.png" large="manual/add-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 
@@ -126,7 +126,7 @@ export default function Page() {
             a new individual, save the activity and come back in to it
             when you&apos;ve created the individual.</p>
     </div>
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="manual/created-activity.png" large="/manual/created-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="manual/created-activity.png" large="manual/created-activity.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100 mt-5"></div>
     <div className="col-md"><h2 className="text-primary">Changing A Diagram</h2></div>
@@ -156,7 +156,7 @@ export default function Page() {
             to model this level of detail becomes more important.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/edit-participant.png" large="/manual/edit-participant.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/edit-participant.png" large="manual/edit-participant.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
 
     <div className="w-100"></div>
@@ -208,7 +208,7 @@ export default function Page() {
             and then click the &lsquo;Sub-tasks&rsquo; button.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/sub-tasks.png" large="/manual/sub-tasks.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/sub-tasks.png" large="manual/sub-tasks.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 
@@ -226,7 +226,7 @@ export default function Page() {
             project is to promote discussion of these questions.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="manual/sub-activities.png" large="/manual/sub-activities.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-100 mb-5" small="manual/sub-activities.png" large="manual/sub-activities.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100 mt-5"></div>
     <div className="col-md"><h2 className="text-primary">Saving and Loading Diagrams</h2></div>
@@ -249,7 +249,7 @@ export default function Page() {
             can be reused across diagrams.</p>
     </div>
 
-    <div className="col text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/save-load-ttl.png" large="/manual/save-load-ttl.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col text-center align-self-center"><picture><ModalImage className="w-50 mb-5" small="manual/save-load-ttl.png" large="manual/save-load-ttl.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 
@@ -261,10 +261,10 @@ export default function Page() {
             <p>The &lsquo;boil an egg&rsquo; example is relatively simple, if
             perhaps analysed to a rather excessive level of detail. The
             &lsquo;crane lift&rsquo; example is the full diagram from <Link
-            href="/crane">the example analysis</Link>.</p>
+            href="crane">the example analysis</Link>.</p>
     </div>
 
-    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-25 mb-5" small="manual/load-example.png" large="/manual/load-example.png" imageBackgroundColor="#fff" alt="" /></picture></div>
+    <div className="col-md text-center align-self-center"><picture><ModalImage className="w-25 mb-5" small="manual/load-example.png" large="manual/load-example.png" imageBackgroundColor="#fff" alt="" /></picture></div>
 
     <div className="w-100"></div>
 

--- a/editor-app/public/examples/index.json
+++ b/editor-app/public/examples/index.json
@@ -1,8 +1,8 @@
 [
     {   "name": "Boil an egg",
-        "path": "/examples/boil-egg.ttl"
+        "path": "examples/boil-egg.ttl"
     },
     {   "name": "Crane lift",
-        "path": "/examples/crane.ttl"
+        "path": "examples/crane.ttl"
     }
 ]


### PR DESCRIPTION
The website is being hosted within a subdirectory of GitHub Pages: https://apollo-protocol.github.io/4d-activity-editor/

Currently, lots of images and some bits of code include `/` at the start of resource references. This breaks down when hosting in a subdirectory as things aren't in the expected location.

The editor page wouldn't load because it would fail to retrieve the list of examples.

I have run `yarn dev` and the images still load, the editor still loads, and the examples still load in.

I am hoping after this PR the GitHub Pages version will have images (some in the footer already worked since no slash present) and the editor will load.