### PR TITLE
Fixed more images and navigation links on GitHub Pages deployment

### DIFF
--- a/editor-app/components/NavBar.tsx
+++ b/editor-app/components/NavBar.tsx
@@ -48,9 +48,9 @@ function CollapsibleExample() {
     >
       <Container className="border-bottom pb-3 mb-3">
       
-      <Link className="navbar-brand" href="/">
-      <picture><img src="Logo_Apollo.png" height="56" alt=""></img></picture>
-  </Link>
+        <Link className="navbar-brand" href="/#">
+          <picture><img src="Logo_Apollo.png" height="56" alt=""></img></picture>
+        </Link>
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
         <Navbar.Collapse id="responsive-navbar-nav">
           <Nav className="me-auto">

--- a/editor-app/pages/index.tsx
+++ b/editor-app/pages/index.tsx
@@ -5,9 +5,6 @@ import { Button, Col, Container, Row } from "react-bootstrap";
 import { ButtonRow, LinkButton } from "@/components/Util";
 import styles from "@/styles/Home.module.css";
 
-import example1 from "@/public/example-diagram1.png";
-import example from "@/public/CraneLift-20230329b.png";
-
 export default function Home() {
   return (
     <>
@@ -73,15 +70,19 @@ export default function Home() {
           <Link className="btn btn-outline-secondary" href="management">Find out more</Link>
         </div>
     </div>
-    <div className="col text-center align-self-center"><Image src={example} alt="
-              A space-time diagram has two axes, Time horizontally and
-              Space vertically. Resources are displayed as horizontal
-              bars spaced along the Space axis. Activities are displayed
-              as boxes spanning the resources they use and their
-              temporal extent on the Time axis. Where a resource
-              participates in an activity the overlapping area is
-              shaded.
-            " className="img-fluid" /></div>
+    <div className="col text-center align-self-center">
+      <picture>
+        <img src="CraneLift-20230329b.png" className="img-fluid" alt="
+                A space-time diagram has two axes, Time horizontally and
+                Space vertically. Resources are displayed as horizontal
+                bars spaced along the Space axis. Activities are displayed
+                as boxes spanning the resources they use and their
+                temporal extent on the Time axis. Where a resource
+                participates in an activity the overlapping area is
+                shaded.
+                "></img>
+      </picture>
+    </div>
   </div>
 </div>
 

--- a/editor-app/pages/intro.tsx
+++ b/editor-app/pages/intro.tsx
@@ -6,9 +6,6 @@ import { ButtonRow, LinkButton } from "@/components/Util";
 
 import styles from "@/styles/Home.module.css";
 
-import flowchart from "@/public/process-for-identifying-decisions-with-numbers.png";
-import example from "@/public/CraneLift-20230329b.png";
-
 export default function Page() {
   return (
     <>
@@ -49,8 +46,8 @@ export default function Page() {
             subsequent information system development.</p>
           </Col>
           <Col className="col-md text-center align-self-center">
-            <Image src={flowchart} alt="The four-step activity modelling 
-            method as a flowchart." className="img-fluid mb-5 mt-3" />
+            <picture><img src="process-for-identifying-decisions-with-numbers.png" className="img-fluid mb-5 mt-3" alt="The four-step activity modelling 
+            method as a flowchart."></img></picture>
           </Col>
         </Row>
         <Row className="justify-content-center row-cols-1 row-cols-lg-2 mt-5">
@@ -105,15 +102,14 @@ export default function Page() {
             here</Link>.</p>
           </Col>
           <Col className="col-md text-center align-self-center">
-            <Image src={example} alt="
+            <picture><img src="CraneLift-20230329b.png" className="img-fluid mb-5" alt="
               A space-time diagram has two axes, Time horizontally and
               Space vertically. Resources are displayed as horizontal
               bars spaced along the Space axis. Activities are displayed
               as boxes spanning the resources they use and their
               temporal extent on the Time axis. Where a resource
               participates in an activity the overlapping area is
-              shaded.
-            " className="img-fluid mb-5" />
+              shaded."></img></picture>
           </Col>
         </Row>
 

--- a/editor-app/pages/management.tsx
+++ b/editor-app/pages/management.tsx
@@ -28,8 +28,7 @@ export default function Page() {
             by a person or by a machine, information is essential; the 
             correct information must be available at the time it is needed
             and of a suitable quality to enable the decision to be made 
-            properly. <b className="text-danger">Reference Apollo protocol 
-            and Matthew&apos;s IMF work.</b></p>
+            properly.</p>
             <p>This page gives an overview of what&apos;s involved in ensuring 
             that information is fit for the collective decisions in an 
             integrated and well managed managed eneterprise. Further information can also be found at: </p>


### PR DESCRIPTION
A few of the images got missed, they should now render ok.

Additionally, the navbar should navigate to the correct subdirectory now. The brand links to `/#` so that it doesn't lose the `/`. Manually navigating without the `/` doesn't seem possible, so we just have to be careful in future not to link to `/` anywhere. Seems link a poor fix but it works for now.

Check `yarn dev` still works ok and renders all images and navigation works.