### PR TITLE
Tweak base URL to get navigation working on GitHub Pages

### DIFF
--- a/editor-app/next.config.js
+++ b/editor-app/next.config.js
@@ -12,7 +12,7 @@ if (isGithubActions) {
   const repo = process.env.GITHUB_REPOSITORY.replace(/.*?\//, '');
 
   assetPrefix = `/${repo}/`;
-  basePath = `/${repo}`;
+  basePath = `/${repo}/`;
   images = {
     loader: 'imgix',
     path: 'apollo-protocol-editor.imgix.net',


### PR DESCRIPTION
On any page, click the brand logo, it takes you to `4d-activity-editor#` then try to click one of the options in the dropdown. It tries to go to `/intro` or whatever and fails

With this `/` on the end of the baseUrl, it might just prevent that.