### PR TITLE
Fix broken GH Pages build and try to get nav links working

### DIFF
--- a/editor-app/components/NavBar.tsx
+++ b/editor-app/components/NavBar.tsx
@@ -57,9 +57,9 @@ function CollapsibleExample() {
             <NavItem href="editor">Editor</NavItem>
             <NavItem href="manual">Guide</NavItem>
             <NavDropdown title="Activity Modelling">
-              <NavDropdown.Item href="intro">Introduction</NavDropdown.Item>
-              <NavDropdown.Item href="crane">Example Analysis</NavDropdown.Item>
-              <NavDropdown.Item href="management">Integrated Information Management</NavDropdown.Item>
+              <NavDropdown.Item href="./intro">Introduction</NavDropdown.Item>
+              <NavDropdown.Item href="./crane">Example Analysis</NavDropdown.Item>
+              <NavDropdown.Item href="./management">Integrated Information Management</NavDropdown.Item>
             </NavDropdown>
           </Nav>
         </Navbar.Collapse>

--- a/editor-app/next.config.js
+++ b/editor-app/next.config.js
@@ -12,7 +12,7 @@ if (isGithubActions) {
   const repo = process.env.GITHUB_REPOSITORY.replace(/.*?\//, '');
 
   assetPrefix = `/${repo}/`;
-  basePath = `/${repo}/`;
+  basePath = `/${repo}`;
   images = {
     loader: 'imgix',
     path: 'apollo-protocol-editor.imgix.net',


### PR DESCRIPTION
Removed the trailing slash as it is not a good fix (it breaks build, so opposite of a fix).

Trying to prepend `./` to links to get them to point at the right URL.