### PR TITLE
Only rebuild to GH Pages when releasing

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,8 +3,8 @@
 name: GitHub Pages Deployment
 
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
Changes the workflow trigger to be on release rather than on every push to main. This gives us more control to release a build on GH Pages when we're happy.
