### PR TITLE
Time events dedupe

### DIFF
--- a/editor-app/lib/ActivityLib.ts
+++ b/editor-app/lib/ActivityLib.ts
@@ -25,9 +25,7 @@ import {
 } from "@apollo-protocol/hqdm-lib";
 import { IndividualImpl } from "./IndividualImpl";
 import { Kind, Model } from "./Model";
-import { STExtent } from "./Schema";
 import { EDITOR_VERSION } from "./version";
-import { Fade } from "react-bootstrap";
 
 /**
  * ActivityLib
@@ -139,7 +137,7 @@ const getTimeValue = (hqdm: HQDMModel, t: Thing): number => {
 };
 
 /**
- * Creates an HQDM point_in_time.
+ * Returns HQDM point_in_time, creating it if it doesn't already exist.
  */
 const createTimeValue = (hqdm: HQDMModel, modelWorld: Thing, time: number): Thing => {
 
@@ -152,19 +150,19 @@ const createTimeValue = (hqdm: HQDMModel, modelWorld: Thing, time: number): Thin
 
   var exists: boolean = false;
   const iri = BASE + uuidv4();
-  var thing = hqdm.createThing(event, iri);
+  var thing = new Thing(iri); // Placeholder thing as we don't know if we need to create one yet.
   
-  // Test whether f already exists in hqdm: HQDMModel
+  // Test whether f value already exists in hqdm: HQDMModel
   hqdm.findByType(event).forEach((obj) => {
     const tVal = hqdm.getEntityName(obj);
     if(tVal == f.toString()){
-      // Time event already exists
       exists = true;
       thing = obj;
     }
   });
 
   if(!exists){
+    thing = hqdm.createThing(event, iri);
     hqdm.addMemberOf(thing, diagramTimeClass);
     hqdm.relate(ENTITY_NAME, thing, new Thing(f.toString()));
     hqdm.addToPossibleWorld(thing, modelWorld);

--- a/editor-app/lib/ActivityLib.ts
+++ b/editor-app/lib/ActivityLib.ts
@@ -27,6 +27,7 @@ import { IndividualImpl } from "./IndividualImpl";
 import { Kind, Model } from "./Model";
 import { STExtent } from "./Schema";
 import { EDITOR_VERSION } from "./version";
+import { Fade } from "react-bootstrap";
 
 /**
  * ActivityLib
@@ -141,9 +142,6 @@ const getTimeValue = (hqdm: HQDMModel, t: Thing): number => {
  * Creates an HQDM point_in_time.
  */
 const createTimeValue = (hqdm: HQDMModel, modelWorld: Thing, time: number): Thing => {
-  const iri = BASE + uuidv4();
-  const thing = hqdm.createThing(event, iri);
-  hqdm.addMemberOf(thing, diagramTimeClass);
 
   /* Map the epoch start and end to +-Inf for output to the file. This
    * is cleaner than leaving magic numbers in the output. Possibly we
@@ -151,8 +149,27 @@ const createTimeValue = (hqdm: HQDMModel, modelWorld: Thing, time: number): Thin
   const f = time < EPOCH_START  ? Number.NEGATIVE_INFINITY
     : time >= EPOCH_END         ? Number.POSITIVE_INFINITY
     : time;
-  hqdm.relate(ENTITY_NAME, thing, new Thing(f.toString()));
-  hqdm.addToPossibleWorld(thing, modelWorld);
+
+  var exists: boolean = false;
+  const iri = BASE + uuidv4();
+  var thing = hqdm.createThing(event, iri);
+  
+  // Test whether f already exists in hqdm: HQDMModel
+  hqdm.findByType(event).forEach((obj) => {
+    const tVal = hqdm.getEntityName(obj);
+    if(tVal == f.toString()){
+      // Time event already exists
+      exists = true;
+      thing = obj;
+    }
+  });
+
+  if(!exists){
+    hqdm.addMemberOf(thing, diagramTimeClass);
+    hqdm.relate(ENTITY_NAME, thing, new Thing(f.toString()));
+    hqdm.addToPossibleWorld(thing, modelWorld);
+  }
+  
   return thing;
 };
 


### PR DESCRIPTION
Fixes #
Addresses [BUG #44](https://github.com/Apollo-Protocol/4d-activity-editor/issues/44#issue-1912869714).  Implemented a de-duplication test in [`createTimeValue()`](https://github.com/Apollo-Protocol/4d-activity-editor/blob/f47aed4a06165ecbe98c2814f4a5a8d64203b5b3/editor-app/lib/ActivityLib.ts#L143) function.

## Changes Proposed:
  Function now:
  - checks if an `event` for the supplied time value already exists in the model.  If so, the function returns the existing `event`.
  - If not, a new `event` is created, added to the model and returned.
 
Testing done by manual inspection of the generated TTL files for situations where activities share event `beginning` and/or `ending` boundaries.
