### PR TITLE
fixed issue where diagram legend was increasing it's width to accomod…

### DIFF
--- a/editor-app/components/DiagramLegend.tsx
+++ b/editor-app/components/DiagramLegend.tsx
@@ -95,7 +95,7 @@ const DiagramLegend = ({
                   key={activity.id}
                   className="legend-item justify-content-between"
                 >
-                  <div className="d-flex align-items-center overflow-hidden">
+                  <div className="legend-item-main">
                     <span
                       className="legend-color-box"
                       style={{
@@ -117,7 +117,7 @@ const DiagramLegend = ({
                     </span>
                   </div>
 
-                  <div className="flex-shrink-0 d-flex gap-1">
+                  <div className="legend-actions d-flex gap-1">
                     {onHighlightActivity && (
                       <OverlayTrigger
                         placement="top"

--- a/editor-app/components/SetParticipation.tsx
+++ b/editor-app/components/SetParticipation.tsx
@@ -79,6 +79,17 @@ const SetParticipation = (props: Props) => {
     setSelectedActivity(undefined);
     setDirty(false);
   };
+
+  // Prevent closing the Modal while inline "edit role" is active. Backdrop
+  // clicks or mouseup outside the dialog during a text selection can close
+  // the modal — ignore those when `editingRoleId` is set.
+  const handleModalHide = () => {
+    if (editingRoleId) {
+      return; // keep modal open while user is editing a role name
+    }
+    handleClose();
+  };
+
   const handleShow = () => {};
   const handleAdd = (event: any) => {
     event.preventDefault();
@@ -243,7 +254,7 @@ const SetParticipation = (props: Props) => {
 
   return (
     <>
-      <Modal show={show} onHide={handleClose} onShow={handleShow}>
+      <Modal show={show} onHide={handleModalHide} onShow={handleShow}>
         <Modal.Header closeButton>
           <Modal.Title>Edit Participation</Modal.Title>
         </Modal.Header>

--- a/editor-app/styles/globals.css
+++ b/editor-app/styles/globals.css
@@ -187,11 +187,13 @@ body {
 /* Legend responsive styles */
 .legend-card {
   transition: all 0.2s ease;
+  width: 100%;
 }
 
 .editor-layout {
   display: grid;
-  grid-template-columns: auto 1fr;
+  --legend-width: 230px;
+  grid-template-columns: var(--legend-width) 1fr;
   grid-template-areas:
     "legend diagram"
     "toolbar toolbar";
@@ -202,6 +204,9 @@ body {
 
 .editor-legend {
   grid-area: legend;
+  width: var(--legend-width);
+  min-width: var(--legend-width);
+  max-width: var(--legend-width);
 }
 
 .editor-diagram {
@@ -294,6 +299,14 @@ body {
   align-items: center;
   margin-bottom: 0.25rem;
   font-size: 0.875rem;
+  min-width: 0;
+}
+
+.legend-item-main {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .legend-color-box {
@@ -307,10 +320,18 @@ body {
 }
 
 .legend-label {
+  display: block;
+  min-width: 0;
   color: #111827;
   white-space: normal;
   word-break: break-word;
+  overflow-wrap: anywhere;
   line-height: 1.3;
+}
+
+.legend-actions {
+  flex-shrink: 0;
+  align-self: flex-start;
 }
 
 .legend-action-btn {
@@ -386,6 +407,12 @@ body {
     grid-template-areas:
       "diagram diagram"
       "legend toolbar";
+  }
+
+  .editor-legend {
+    width: auto;
+    min-width: 0;
+    max-width: none;
   }
 
   .legend-sticky {


### PR DESCRIPTION
This pull request improves the layout, styling, and usability of the diagram legend and participation modal in the editor app. Key changes include enhanced legend responsiveness and alignment, better handling of modal closure during inline editing, and CSS refactoring for consistent sizing and structure.

**Legend layout and styling improvements:**
- Refactored the legend item structure in `DiagramLegend.tsx` to use new CSS classes (`legend-item-main`, `legend-actions`) for improved alignment and responsiveness. [[1]](diffhunk://#diff-527fb1ffbfc43b2e6b2fee1aa0b87b7057ec400f270487c63a9c62837c256165L98-R98) [[2]](diffhunk://#diff-527fb1ffbfc43b2e6b2fee1aa0b87b7057ec400f270487c63a9c62837c256165L120-R120)
- Updated global styles in `globals.css` to set a fixed legend width using a CSS variable, ensure the legend is fully responsive, and apply consistent sizing and alignment to legend elements. [[1]](diffhunk://#diff-e520f1911a7d05f387b664369891780e4ff21cf2b66c7f5488b13c054e2a3a0fR190-R196) [[2]](diffhunk://#diff-e520f1911a7d05f387b664369891780e4ff21cf2b66c7f5488b13c054e2a3a0fR207-R209) [[3]](diffhunk://#diff-e520f1911a7d05f387b664369891780e4ff21cf2b66c7f5488b13c054e2a3a0fR302-R309) [[4]](diffhunk://#diff-e520f1911a7d05f387b664369891780e4ff21cf2b66c7f5488b13c054e2a3a0fR323-R336) [[5]](diffhunk://#diff-e520f1911a7d05f387b664369891780e4ff21cf2b66c7f5488b13c054e2a3a0fR412-R417)

**Participation modal usability:**
- Added logic to prevent the participation modal from closing when an inline "edit role" action is active, improving the user experience during role editing. [[1]](diffhunk://#diff-04203611a2336b111b27ace55fdf6f8a52b5122833ddf15b7e2a5305907776d4R82-R92) [[2]](diffhunk://#diff-04203611a2336b111b27ace55fdf6f8a52b5122833ddf15b7e2a5305907776d4L246-R257)
