### PR TITLE
Fix favicon handling and improve z-index for modal dialogs

### DIFF
--- a/editor-app/components/ActivityDiagram.tsx
+++ b/editor-app/components/ActivityDiagram.tsx
@@ -192,6 +192,7 @@ const ActivityDiagram = (props: Props) => {
   }, [responsiveDefaultMinimapScale]);
 
   const isMobileLegendLayout = viewportWidth <= 767.98;
+  const mobileDiagramWidth = Math.max(plot.width, Math.round(viewportWidth * 1.9));
 
   const searchableEntities = useMemo(() => {
     return Array.from(dataset.individuals.values())
@@ -350,7 +351,8 @@ const ActivityDiagram = (props: Props) => {
         rightClickActivity,
         rightClickParticipation,
         hideNonParticipating,
-        collapsedSystems
+        collapsedSystems,
+        isMobileLegendLayout
       )
     );
   }, [
@@ -367,6 +369,7 @@ const ActivityDiagram = (props: Props) => {
     rightClickParticipation,
     hideNonParticipating,
     collapsedSystems,
+    isMobileLegendLayout,
   ]);
 
   useEffect(() => {
@@ -970,6 +973,17 @@ const ActivityDiagram = (props: Props) => {
             variant={interactionMode === "zoom" ? "primary" : "secondary"}
             size="sm"
             onClick={() => setInteractionMode("zoom")}
+            onDoubleClick={(e) => {
+              e.preventDefault();
+              zoomTransformRef.current = d3.zoomIdentity;
+              if (svgRef.current) {
+                const svg = d3.select(svgRef.current);
+                svg.select("#activity-diagram-group").attr("transform", d3.zoomIdentity.toString());
+                if (zoomRef.current) {
+                  svg.call(zoomRef.current.transform, d3.zoomIdentity);
+                }
+              }
+            }}
             onContextMenu={(e) => {
               e.preventDefault();
               zoomTransformRef.current = d3.zoomIdentity;
@@ -982,7 +996,7 @@ const ActivityDiagram = (props: Props) => {
               }
             }}
             aria-pressed={interactionMode === "zoom"}
-            title="Zoom mode (right-click to reset)"
+            title="Zoom mode (double-click or right-click to reset)"
             style={{ width: "2.2em", height: "2.2em", padding: 0, display: "flex", alignItems: "center", justifyContent: "center" }}
           >
             <svg width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true">
@@ -1231,8 +1245,9 @@ const ActivityDiagram = (props: Props) => {
             viewBox={`0 0 ${plot.width} ${plot.height}`}
             ref={svgRef}
             style={{
-              minWidth: "100%",
-              maxWidth: "100%",
+              width: isMobileLegendLayout ? `${mobileDiagramWidth}px` : "100%",
+              minWidth: isMobileLegendLayout ? `${mobileDiagramWidth}px` : "100%",
+              maxWidth: isMobileLegendLayout ? "none" : "100%",
             }}
           />
         </div>

--- a/editor-app/components/SetActivity.tsx
+++ b/editor-app/components/SetActivity.tsx
@@ -1046,6 +1046,8 @@ const SetActivity = (props: Props) => {
                 // @ts-ignore
                 getOptionValue={(option) => option.optionKey}
                 onChange={handleChangeMultiselect}
+                menuPortalTarget={typeof document !== "undefined" ? document.body : undefined}
+                styles={{ menuPortal: (base: any) => ({ ...base, zIndex: 9999 }) }}
               />
             </Form.Group>
           </Form>

--- a/editor-app/diagram/DrawActivities.ts
+++ b/editor-app/diagram/DrawActivities.ts
@@ -16,11 +16,13 @@ import {
   splitParticipationByInstallations,
   ParticipationSegment,
 } from "@/utils/installations";
+import { getDiagramFontFamily } from "@/utils/appearance";
 
 let mouseOverElement: any | null = null;
 
 export function drawActivities(ctx: DrawContext) {
   const { config, svgElement, activities, individuals, dataset, collapsedSystems } = ctx;
+  const activityVerticalScale = Math.max(0.1, Math.min(1, config.viewPort.activityVerticalScale ?? 1));
 
   if (activities.length === 0) {
     return svgElement;
@@ -93,20 +95,29 @@ export function drawActivities(ctx: DrawContext) {
       return x + timeInterval * (a.beginning - startOfTime);
     })
     .attr("y", (a: Activity) => {
-      return (
-        calculateTopPositionOfNewActivity(svgElement, a, individuals, dataset, collapsedSystems) -
-        config.layout.individual.gap * 0.3
-      );
+      return getActivityRectMetrics(
+        svgElement,
+        a,
+        individuals,
+        dataset,
+        collapsedSystems,
+        config.layout.individual.gap,
+        activityVerticalScale
+      ).y;
     })
     .attr("width", (a: Activity) => {
       return (a.ending - a.beginning) * timeInterval;
     })
     .attr("height", (a: Activity) => {
-      const bottomY = calculateLengthOfNewActivity(svgElement, a, individuals, dataset, collapsedSystems);
-      const topY = calculateTopPositionOfNewActivity(svgElement, a, individuals, dataset, collapsedSystems);
-      return bottomY
-        ? bottomY - topY + config.layout.individual.gap * 0.6
-        : 0;
+      return getActivityRectMetrics(
+        svgElement,
+        a,
+        individuals,
+        dataset,
+        collapsedSystems,
+        config.layout.individual.gap,
+        activityVerticalScale
+      ).height;
     })
     .attr("stroke", (a: Activity, i: number) => {
       return config.presentation.activity.stroke[
@@ -125,14 +136,26 @@ export function drawActivities(ctx: DrawContext) {
   // small helper functions to reuse computations
   const xOf = (a: Activity) => x + timeInterval * (a.beginning - startOfTime);
   const yOf = (a: Activity) =>
-    calculateTopPositionOfNewActivity(svgElement, a, individuals, dataset, collapsedSystems) -
-    config.layout.individual.gap * 0.3;
+    getActivityRectMetrics(
+      svgElement,
+      a,
+      individuals,
+      dataset,
+      collapsedSystems,
+      config.layout.individual.gap,
+      activityVerticalScale
+    ).y;
   const widthOf = (a: Activity) => (a.ending - a.beginning) * timeInterval;
-  const heightOf = (a: Activity) => {
-    const bottomY = calculateLengthOfNewActivity(svgElement, a, individuals, dataset, collapsedSystems);
-    const topY = calculateTopPositionOfNewActivity(svgElement, a, individuals, dataset, collapsedSystems);
-    return bottomY ? bottomY - topY + config.layout.individual.gap * 0.6 : 0;
-  };
+  const heightOf = (a: Activity) =>
+    getActivityRectMetrics(
+      svgElement,
+      a,
+      individuals,
+      dataset,
+      collapsedSystems,
+      config.layout.individual.gap,
+      activityVerticalScale
+    ).height;
 
   // Subtask badge rendering removed — badge no longer drawn on activities.
 
@@ -147,8 +170,39 @@ function labelActivities(
   timeInterval: number,
   startOfTime: number
 ) {
-  // Labels are now provided via the external legend; do not draw activity text on the SVG.
-  return;
+  if (!ctx.showActivityLabels) {
+    return;
+  }
+
+  const { svgElement, activities } = ctx;
+  const diagramFontFamily = getDiagramFontFamily();
+
+  svgElement.selectAll(".activityLabel").remove();
+
+  activities.forEach((activity) => {
+    const rect = svgElement.select(`#a${activity.id}`);
+    if (rect.empty()) return;
+
+    const x = parseFloat(rect.attr("x") || "0");
+    const y = parseFloat(rect.attr("y") || "0");
+    const width = parseFloat(rect.attr("width") || "0");
+    const height = parseFloat(rect.attr("height") || "0");
+
+    if (width <= 0 || height <= 0) return;
+
+    svgElement
+      .append("text")
+      .attr("class", "activityLabel")
+      .attr("id", `al${activity.id}`)
+      .attr("x", x + width / 2)
+      .attr("y", y + height / 2 + 4)
+      .attr("text-anchor", "middle")
+      .attr("font-family", diagramFontFamily)
+      .attr("font-size", "0.7em")
+      .attr("fill", "#441d62")
+      .attr("pointer-events", "none")
+      .text(activity.name || "");
+  });
 }
 
 export function hoverActivities(ctx: DrawContext) {
@@ -228,6 +282,31 @@ function calculateLengthOfNewActivity(
   collapsedSystems?: ReadonlySet<string>
 ) {
   return calculateActivityBottom(svgElement, activity, individuals, dataset, collapsedSystems);
+}
+
+function getActivityRectMetrics(
+  svgElement: any,
+  activity: Activity,
+  individuals: Individual[],
+  dataset: Model | undefined,
+  collapsedSystems: ReadonlySet<string> | undefined,
+  gap: number,
+  activityVerticalScale: number
+) {
+  const topY = calculateTopPositionOfNewActivity(svgElement, activity, individuals, dataset, collapsedSystems);
+  const bottomY = calculateLengthOfNewActivity(svgElement, activity, individuals, dataset, collapsedSystems);
+  const rawY = topY - gap * 0.3;
+  const rawHeight = bottomY ? bottomY - topY + gap * 0.6 : 0;
+
+  if (rawHeight <= 0 || activityVerticalScale === 1) {
+    return { y: rawY, height: rawHeight };
+  }
+
+  const scaledHeight = rawHeight * activityVerticalScale;
+  return {
+    y: rawY + (rawHeight - scaledHeight) / 2,
+    height: scaledHeight,
+  };
 }
 
 /**

--- a/editor-app/diagram/DrawActivityDiagram.ts
+++ b/editor-app/diagram/DrawActivityDiagram.ts
@@ -48,7 +48,8 @@ export function drawActivityDiagram(
   rightClickActivity: (a: Activity) => void,
   rightClickParticipation: (a: Activity, p: Participation) => void,
   hideNonParticipating: boolean = false,
-  collapsedSystems?: ReadonlySet<string>
+  collapsedSystems?: ReadonlySet<string>,
+  showActivityLabels: boolean = false
 ) {
   //Prepare Model data into arrays
   let individualsArray: Individual[] = [];
@@ -155,6 +156,7 @@ export function drawActivityDiagram(
     activities: activitiesArray,
     individuals: individualsArray,
     collapsedSystems,
+    showActivityLabels,
   };
 
   drawIndividuals(drawCtx);

--- a/editor-app/diagram/DrawHelpers.ts
+++ b/editor-app/diagram/DrawHelpers.ts
@@ -18,6 +18,7 @@ export interface DrawContext {
   activities: Activity[];
   individuals: Individual[];
   collapsedSystems?: ReadonlySet<string>;
+  showActivityLabels?: boolean;
 }
 
 export interface Label {

--- a/editor-app/diagram/config.ts
+++ b/editor-app/diagram/config.ts
@@ -4,6 +4,7 @@ export interface ConfigData {
     x: number;
     minTimelineSpan: number;
     timelineBuffer: number;
+    activityVerticalScale: number;
   };
   layout: {
     individual: {
@@ -83,6 +84,7 @@ export const config: ConfigData = {
     x: 1000,
     minTimelineSpan: 11,
     timelineBuffer: 2,
+    activityVerticalScale: 1,
   },
   layout: {
     individual: {

--- a/editor-app/modals/DraggableModalDialog.tsx
+++ b/editor-app/modals/DraggableModalDialog.tsx
@@ -61,7 +61,7 @@ const DraggableModalDialog = forwardRef<HTMLDivElement, ModalDialogProps>((props
   }, []);
 
   return (
-    <Draggable handle=".modal-header" nodeRef={nodeRef}>
+    <Draggable handle=".modal-header" cancel=".btn-close" nodeRef={nodeRef}>
       <ModalDialog {...props} ref={nodeRef} />
     </Draggable>
   );

--- a/editor-app/pages/_document.tsx
+++ b/editor-app/pages/_document.tsx
@@ -4,6 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <link rel="icon" href={`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/favicon.ico`} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link

--- a/editor-app/pages/crane.tsx
+++ b/editor-app/pages/crane.tsx
@@ -86,7 +86,6 @@ export default function Page({ imageMap }: { imageMap: Record<string, string> })
       <Head>
         <title>Analysing a Crane Lift | Activity Diagram Editor</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
       <div className="row">

--- a/editor-app/pages/editor.tsx
+++ b/editor-app/pages/editor.tsx
@@ -8,7 +8,6 @@ export default function Editor() {
         <title>Editor | Activity Diagram Editor</title>
         <meta name="description" content="4d activity model development tool" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="favicon.ico" />
       </Head>
 
       <ActivityDiagramWrap />

--- a/editor-app/pages/index.tsx
+++ b/editor-app/pages/index.tsx
@@ -13,7 +13,6 @@ export default function Home() {
       <title>Activity Diagram Editor</title>
       <meta name="description" content="HDQM activity diagram editor" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <link rel="icon" href="favicon.ico" />
     </Head>
     <Container>
     <div className="container ">

--- a/editor-app/pages/intro.tsx
+++ b/editor-app/pages/intro.tsx
@@ -22,7 +22,6 @@ export default function Page() {
       <Head>
         <title>Activity Modelling Introduction | Activity Diagram Editor</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
       <div className="row">

--- a/editor-app/pages/management.tsx
+++ b/editor-app/pages/management.tsx
@@ -37,7 +37,6 @@ export default function Page() {
       <Head>
         <title>Integrated Information Management | Activity Diagram Editor</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
         <div className="row">

--- a/editor-app/pages/manual.tsx
+++ b/editor-app/pages/manual.tsx
@@ -161,7 +161,6 @@ export default function Page({ imageMap }: { imageMap: Record<string, string> })
         <title>Editor Guide | Activity Diagram Editor</title>
         <meta name="description" content="Comprehensive guide to the Activity Diagram Editor" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
         <div className="row">
@@ -430,7 +429,7 @@ export default function Page({ imageMap }: { imageMap: Record<string, string> })
               <Col>
                 <h4 id="trim-remove-keep" className="doc-section-heading">Trim, Remove and Keep</h4>
                 <p>
-                  Both warning dialogs use three colour-coded action badges
+                  The warning dialog uses three colour-coded action badges
                   to communicate the outcome for each item:
                 </p>
                 <ul>
@@ -827,7 +826,7 @@ export default function Page({ imageMap }: { imageMap: Record<string, string> })
                   entity rows the same height so labels remain readable.
                 </p>
                 <p>
-                  To reset the zoom back to the normal level, right-click on the zoom icon.
+                  To reset the zoom back to the normal level, double-click or right-click on the zoom icon.
                 </p>
               </Col>
               <Col className="col-md text-center align-self-center">

--- a/editor-app/pages/system-example.tsx
+++ b/editor-app/pages/system-example.tsx
@@ -65,7 +65,6 @@ export default function Page({ imageMap }: { imageMap: Record<string, string> })
       <Head>
         <title>System Component Example Analysis | Activity Diagram Editor</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
         <div className="row">

--- a/editor-app/pages/system-intro.tsx
+++ b/editor-app/pages/system-intro.tsx
@@ -68,7 +68,6 @@ export default function Page({ imageMap }: { imageMap: Record<string, string> })
       <Head>
         <title>System and System Component Modelling | Activity Diagram Editor</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="favicon.ico" />
       </Head>
       <Container>
         <div className="row">

--- a/editor-app/styles/globals.css
+++ b/editor-app/styles/globals.css
@@ -2029,6 +2029,12 @@ html.app-custom-theme .diagram-search-input:focus {
     width: 0.8rem;
     height: 0.8rem;
   }
+
+  .diagram-search-popover {
+    width: calc(100vw - 2rem);
+    max-width: 17.5rem;
+    right: -0.5rem;
+  }
 }
 
 /* React-select dark theme support */
@@ -4067,6 +4073,15 @@ html.app-custom-theme .breadcrumb-wrapper .breadcrumb-item a:hover {
     font-size: 0.75rem;
   }
 
+  .color-scheme-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .color-scheme-custom-btn {
+    flex: 0 0 calc((100% - 0.5rem) / 2);
+    max-width: calc((100% - 0.5rem) / 2);
+  }
+
   .modal-anim-grid {
     gap: 0.5rem;
   }
@@ -4146,7 +4161,7 @@ html.app-custom-theme .breadcrumb-wrapper .breadcrumb-item a:hover {
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.10);
   overflow: visible;
-  z-index: 30;
+  z-index: 1090;
   opacity: 1;
 }
 .diagram-minimap-header {
@@ -4218,7 +4233,7 @@ html.app-custom-theme .breadcrumb-wrapper .breadcrumb-item a:hover {
   background: var(--bs-body-bg, #fff);
   box-shadow: 0 2px 12px rgba(0,0,0,0.18);
   overflow: hidden;
-  z-index: 31;
+  z-index: 1091;
 }
 .diagram-minimap-lens svg {
   display: block;
@@ -4251,6 +4266,9 @@ html.app-custom-theme .breadcrumb-wrapper .breadcrumb-item a:hover {
 
   .editor-toolbar {
     align-self: start;
+    position: relative;
+    z-index: 1100;
+    overflow: visible;
   }
 
   .editor-legend .legend-card:first-child {
@@ -4261,6 +4279,9 @@ html.app-custom-theme .breadcrumb-wrapper .breadcrumb-item a:hover {
     display: block;
     grid-column: 1 / -1;
     min-width: 0;
+    position: relative;
+    z-index: 1100;
+    overflow: visible;
   }
 
   .toolbar-mobile-minimap-host:empty {


### PR DESCRIPTION
Fixes #

This pull request introduces several improvements and fixes across the activity diagram editor, focusing on enhanced diagram rendering, better mobile responsiveness, improved usability, and minor UI/UX polish. The most notable changes are the addition of vertical scaling for activity rectangles, support for activity labels on diagrams, improved zoom reset interactions, and updates to favicon handling.

**Activity diagram rendering and scaling:**

- Added a new `activityVerticalScale` configuration option, allowing vertical scaling of activity rectangles for better control over diagram appearance. Updated all relevant rendering logic to use a new helper (`getActivityRectMetrics`) for consistent rectangle sizing and positioning. [[1]](diffhunk://#diff-bc0013f617eee670313fa5d2193a58de69c5d5f7e9dbf788e28a549fb70dce60R7) [[2]](diffhunk://#diff-bc0013f617eee670313fa5d2193a58de69c5d5f7e9dbf788e28a549fb70dce60R87) [[3]](diffhunk://#diff-d59fda8d06cd7403b558cb426d2b1f0716999b7cfebd981a6181754ada27bc79R19-R25) [[4]](diffhunk://#diff-d59fda8d06cd7403b558cb426d2b1f0716999b7cfebd981a6181754ada27bc79L96-R120) [[5]](diffhunk://#diff-d59fda8d06cd7403b558cb426d2b1f0716999b7cfebd981a6181754ada27bc79L128-R158) [[6]](diffhunk://#diff-d59fda8d06cd7403b558cb426d2b1f0716999b7cfebd981a6181754ada27bc79R287-R311)
- Introduced support for displaying activity labels directly on the diagram SVG, controlled by a new `showActivityLabels` flag and passed through the drawing context. [[1]](diffhunk://#diff-09a488762fe26cf42e6ef39dbe645a5d48c17344b72b67cbc94f227f188f8bc1L51-R52) [[2]](diffhunk://#diff-09a488762fe26cf42e6ef39dbe645a5d48c17344b72b67cbc94f227f188f8bc1R159) [[3]](diffhunk://#diff-66d2466be8de14cf4f39fecbe9b75c6b1a7b92e8aa7e981151d30c08f1dbab6bR21) [[4]](diffhunk://#diff-d59fda8d06cd7403b558cb426d2b1f0716999b7cfebd981a6181754ada27bc79L150-R207)

**Mobile and responsive improvements:**

- Enhanced mobile diagram layout by dynamically adjusting diagram width and related SVG sizing when in mobile legend layout mode, improving usability on small screens. [[1]](diffhunk://#diff-211513b92ab481da57e9eca156e17e538d12c598e8a8d635fc3aa2515c20e29bR195) [[2]](diffhunk://#diff-211513b92ab481da57e9eca156e17e538d12c598e8a8d635fc3aa2515c20e29bL353-R355) [[3]](diffhunk://#diff-211513b92ab481da57e9eca156e17e538d12c598e8a8d635fc3aa2515c20e29bR372) [[4]](diffhunk://#diff-211513b92ab481da57e9eca156e17e538d12c598e8a8d635fc3aa2515c20e29bL1234-R1250)
- Improved the styling of the diagram search popover for mobile devices to ensure proper sizing and placement.

**User interaction and accessibility:**

- Improved zoom mode reset: users can now double-click the zoom icon to reset zoom, in addition to right-clicking. This is reflected in both the UI logic and tooltip descriptions. [[1]](diffhunk://#diff-211513b92ab481da57e9eca156e17e538d12c598e8a8d635fc3aa2515c20e29bR976-R986) [[2]](diffhunk://#diff-211513b92ab481da57e9eca156e17e538d12c598e8a8d635fc3aa2515c20e29bL985-R999) [[3]](diffhunk://#diff-4e1c5d2af0fbedbd7951abfcc9badb0c27778b3186adceaf5f888d059948b723L830-R829)
- Updated the draggable modal dialog to prevent accidental dragging when clicking the close button, enhancing modal usability.
- Added support for rendering the multi-select dropdown menu in a portal with a high z-index, ensuring it displays correctly above other UI elements.

**UI/UX and documentation:**

- Centralized favicon handling by adding the favicon link to the main `_document.tsx` file and removing redundant favicon links from individual pages, ensuring consistent favicon usage throughout the app. [[1]](diffhunk://#diff-b7d11ff6f37a1d8d2f41578f293cef7eadaec41e947b7ac3b822b0e794f9bbbdR7) [[2]](diffhunk://#diff-b13aa29d60f6ed36c501ea9c0b5aa4b22dc49353bfe1041e2876c7cdcd06f51bL89) [[3]](diffhunk://#diff-5bf3cde949d2f74f3ab0cdfd6aaf11ce08c7c74c1ec5c6501bec9d1a1dc6a877L11) [[4]](diffhunk://#diff-6f305fbfcfa35b7a1775cd1b0370216e6eef859a3800e3506cefdac13957b98aL16) [[5]](diffhunk://#diff-123ab7f18ec436d77e79601290a835c21e416d534f1d503e2f817e6dcb307883L25) [[6]](diffhunk://#diff-77fc55defb32c5f953c5c05b3c095f41c4bf9a07fc1505473cf47609e7f9a0d6L40) [[7]](diffhunk://#diff-4e1c5d2af0fbedbd7951abfcc9badb0c27778b3186adceaf5f888d059948b723L164) [[8]](diffhunk://#diff-145804d982810651b33c44218d1e83bdba5a75dea6fdab94571bca7e1227d2e4L68) [[9]](diffhunk://#diff-0f6fa562acad82cebbdd16a3cc656cb924e1f54938c6d84d92dac507b74ba30fL71)
- Minor documentation and content corrections in the manual, such as clarifying badge usage and updating zoom reset instructions. [[1]](diffhunk://#diff-4e1c5d2af0fbedbd7951abfcc9badb0c27778b3186adceaf5f888d059948b723L433-R432) [[2]](diffhunk://#diff-4e1c5d2af0fbedbd7951abfcc9badb0c27778b3186adceaf5f888d059948b723L830-R829)
